### PR TITLE
Add watchSearch config option used for watch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ module.exports = {
   // The directory where Jest test files are stored.
   // By default stored as *.test.js adjacent with the files they are testing).
   testPath: 'src',
+  
+  // The search pattern for watching files for changes.
+  watchSearch: 'src/**/*.js',
+}
 ```
 
 ### Create your local gulpfile.js

--- a/functions/watchFull.js
+++ b/functions/watchFull.js
@@ -8,7 +8,7 @@ const testQuick = require('./testQuick')
  * Watch for changes and run the distribution for the changed files, then bundle and test the changed files.
  * @returns {*}
  */
-const watchFull = () => watch(gulpConfig.srcSearch)
+const watchFull = () => watch(gulpConfig.watchSearch)
   .on('change', path => {
     const pathRegex = new RegExp(`^${gulpConfig.srcPath}(.*\\/).+\\.js$`, 'i')
     const distForPath = () => distFor(path, path.replace(pathRegex, `${gulpConfig.distPath}$1`))

--- a/functions/watchTest.js
+++ b/functions/watchTest.js
@@ -6,6 +6,6 @@ const testQuick = require('./testQuick')
  * Watch for changes and run the tests.
  * @returns {*}
  */
-const watchTest = () => watch(gulpConfig.srcSearch, { ignoreInitial: false }, series(testQuick))
+const watchTest = () => watch(gulpConfig.watchSearch, { ignoreInitial: false }, series(testQuick))
 
 module.exports = watchTest

--- a/gulp.config.js
+++ b/gulp.config.js
@@ -15,4 +15,5 @@ module.exports = {
   srcPath: defaultConfig(parentConfig, 'srcPath', 'src'),
   srcSearch: defaultConfig(parentConfig, 'srcSearch', 'src/**/!(*.test).js'),
   testPath: defaultConfig(parentConfig, 'testPath', ['src']),
+  watchSearch: defaultConfig(parentConfig, 'watchSearch', 'src/**/*.js'),
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-build-tools",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Standardised build process with gulp.",
   "main": "gulpfile.base.js",
   "scripts": {


### PR DESCRIPTION
Add ability to configure different route for watch pattern rather than just using same route as srcSearch.
 - With the default options, test files were being excluded from the watch pattern.